### PR TITLE
Hotfix - Doctrine Exception 

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 
-MYDDLEWARE_VERSION=3.1.0
+MYDDLEWARE_VERSION=3.1.1
 APP_SECRET=Thissecretisnotsosecretchangeit
 APP_ENV=prod
 APP_DEBUG=false

--- a/src/Controller/InstallRequirementsController.php
+++ b/src/Controller/InstallRequirementsController.php
@@ -4,7 +4,7 @@ namespace App\Controller;
 
 use App\Repository\ConfigRepository;
 use Doctrine\DBAL\ConnectionException as DoctrineConnectionException;
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\Exception as DBALException;
 use Doctrine\DBAL\Driver\PDO\Exception as DoctrinePDOException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Exception;


### PR DESCRIPTION
Doctrine upgraded generated a wrongful redirect at installation (but did not trigger any error messages). 