### PR TITLE
hotfix: prevent error when trying to access a page anonymously

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-MYDDLEWARE_VERSION=3.1.3
+MYDDLEWARE_VERSION=3.1.4
 
 APP_SECRET=Thissecretisnotsosecretchangeit
 APP_ENV=prod

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -46,9 +46,9 @@ security:
         ROLE_SUPER_ADMIN: ROLE_ADMIN
 
     access_control:
-        - { path: ~/$, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ~/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ~/admin/, role: ROLE_ADMIN }
-        - { path: ~/rule/, role: ROLE_USER }
-        - { path: ~/api/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ~/api,       roles: IS_AUTHENTICATED_FULLY }
+        - { path: /$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/admin/, role: ROLE_ADMIN }
+        - { path: ^/rule/, role: ROLE_USER }
+        - { path: ^/api/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/api,       roles: IS_AUTHENTICATED_FULLY }

--- a/src/Controller/ConnectorController.php
+++ b/src/Controller/ConnectorController.php
@@ -482,7 +482,7 @@ class ConnectorController extends AbstractController
             $compact = $this->nav_pagination([
                 'adapter_em_repository' => $this->entityManager->getRepository(Connector::class)
                                             ->findListConnectorByUser($this->getUser()->isAdmin(), $this->getUser()->getId()),
-                'maxPerPage' => $this->params['pager'],
+                'maxPerPage' => isset($this->params['pager']) ? $this->params['pager'] : 20,
                 'page' => $page,
             ]);
 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -228,7 +228,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
                 $compact = $this->nav_pagination([
                     'adapter_em_repository' => $this->entityManager->getRepository(Rule::class)->findListRuleByUser($this->getUser()),
-                    'maxPerPage' => $this->params['pager'],
+                    'maxPerPage' => isset($this->params['pager']) ? $this->params['pager'] : 20,
                     'page' => $page,
                 ]);
 

--- a/src/Controller/FluxController.php
+++ b/src/Controller/FluxController.php
@@ -376,7 +376,7 @@ class FluxController extends AbstractController
         $r = $this->documentRepository->getFluxPagination($data);
         $compact = $this->nav_pagination([
             'adapter_em_repository' => $r,
-            'maxPerPage' => $this->params['pager'],
+            'maxPerPage' => isset($this->params['pager']) ? $this->params['pager'] : 25,
             'page' => $page,
         ], false);
 

--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -114,7 +114,7 @@ class TaskController extends AbstractController
         $jobs = $this->jobRepository->findBy([], ['status' => 'DESC', 'begin' => 'DESC'], 1000);
         $compact = $this->nav_pagination([
             'adapter_em_repository' => $jobs,
-            'maxPerPage' => $this->params['pager'],
+            'maxPerPage' => isset($this->params['pager']) ? $this->params['pager'] : 25,
             'page' => $page,
         ], false);
 
@@ -151,7 +151,7 @@ class TaskController extends AbstractController
             $taskId = $task->getId();
             $compact = $this->nav_pagination([
                 'adapter_em_repository' => $em->getRepository(Log::class)->findBy(['job' => $taskId], ['id' => 'DESC']),
-                'maxPerPage' => $this->params['pager'],
+                'maxPerPage' => isset($this->params['pager']) ? $this->params['pager'] : 25,
                 'page' => $page,
             ], false);
             //Check the user timezone


### PR DESCRIPTION
1) Fixed wrongful call to findListRuleByUser(User $user) from DefaultController.php line 230 by  reverting security.yaml access_control path syntax. 

Way to reproduce the fixed issue : 
- Myddleware version 3.1.3
- try to anonymously access routes such as /rule/list or /rule/connector/list
=> If in production, a 500 error was triggered, now it should redirect to login page.

2) Fixed pagination errors being triggered when DoctrineFixtures haven't yet been loaded (undefined index $params['pager'] in maxPerPage property for PagerFantaBundle)